### PR TITLE
Сигнатура формируется в ловеркейсе, тогда как приходить в верхнем регистре.

### DIFF
--- a/app/controllers/robokassa_controller.rb
+++ b/app/controllers/robokassa_controller.rb
@@ -6,20 +6,20 @@ class RobokassaController < ApplicationController
     if @notification.valid_result_signature?
       render text: @notification.success
     else
-      render text: "fail"
+      Rubykassa.fail_callback.call
     end
   end
 
   def success
     if @notification.valid_success_signature?
-      render text: "success"
+      Rubykassa.success_callback.call
     else
-      render text: "fail"
+      Rubykassa.fail_callback.call
     end
   end
 
   def fail
-    render text: "fail"
+    Rubykassa.fail_callback.call
   end
 
   private

--- a/lib/rubykassa.rb
+++ b/lib/rubykassa.rb
@@ -12,7 +12,7 @@ module Rubykassa
     Rubykassa::Client.configure &block
   end
 
-  %w(login first_password second_password mode http_method xml_http_method).map do |name|
+  %w(login first_password second_password mode http_method xml_http_method success_callback fail_callback).map do |name|
     define_method name do
       Rubykassa::Client.configuration.send(name)
     end

--- a/lib/rubykassa/configuration.rb
+++ b/lib/rubykassa/configuration.rb
@@ -2,6 +2,8 @@
 module Rubykassa
   class Configuration
     attr_accessor :login, :first_password, :second_password, :mode, :http_method, :xml_http_method
+    attr_accessor :success_callback
+    attr_accessor :fail_callback
 
     def initialize
       self.login = "your_login"
@@ -9,7 +11,9 @@ module Rubykassa
       self.second_password = "second_password"
       self.mode = :test
       self.http_method = :get
-      self.xml_http_method = :get      
+      self.xml_http_method = :get
+      self.success_callback = -> {}
+      self.fail_callback = -> {}
     end
   end
 end

--- a/spec/rubykassa/client_configuration_spec.rb
+++ b/spec/rubykassa/client_configuration_spec.rb
@@ -32,6 +32,18 @@ describe Rubykassa::Client do
     Rubykassa.mode.should == :test
     Rubykassa.http_method.should == :get
     Rubykassa.http_method.should == :get
+    expect(Rubykassa.success_callback).to be_instance_of(Proc)
+    expect(Rubykassa.fail_callback).to be_instance_of(Proc)
+  end
+
+  it "should set success_callback" do
+    Rubykassa.configure do |config|
+      config.success_callback = -> {
+        2 + 5
+      }
+    end
+
+    expect(Rubykassa.success_callback.call).to eq(7)
   end
 
   it "should raise error when wrong mode is set" do


### PR DESCRIPTION
https://github.com/ZeroOneStudio/rubykassa/blob/master/lib/rubykassa/notification.rb#L18

```
    %w(result success).map do |kind|
      define_method "valid_#{kind}_signature?" do
        p @params["SignatureValue"]
        p generate_signature_for(kind.to_sym)
        @params["SignatureValue"] == generate_signature_for(kind.to_sym)
      end
    end
```

Результат:
"2EDA28FE398EA1C84FA2F6D86B5F35E9"
"2eda28fe398ea1c84fa2f6d86b5f35e9"
