### PR TITLE
Add html_options for pay_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Edge (not released)
+* Add support html options in params.
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Additionally you may want to pass extra options. There is no problem:
 
     <%= pay_url "Pay with Robokassa", ivoice_id, total_sum, { description: "Invoice description", email: "foo@bar.com", currency: "WMZM", culture: :ru } %>
 
+HTML options example:
+
+    <%= pay_url "Pay with Robokassa", ivoice_id, total_sum, { html: { class: 'btn btn-primary btn-bg' }}
+
 Or if you would like to pass some custom params use `custom` key in options hash:
 
     <%= pay_url "Pay with Robokassa", ivoice_id, total_sum, { description: "Invoice description", email: "foo@bar.com", currency: "WMZM", culture: :ru, custom: { param1: "value1", param2: "value2" }} %>        

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -3,9 +3,10 @@ module Rubykassa
   module ActionViewExtension
     def pay_url phrase, invoice_id, total, options = {}
       total, invoice_id  = total.to_s, invoice_id.to_s
-      extra_params  = options.except(:custom)
+      extra_params  = options.except([:custom, :html])
       custom_params = options[:custom] ||= {}
-      link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params)
+      html_params = options[:html] ||= {}
+      link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params
     end
   end
 end


### PR DESCRIPTION
Здравствуйте.
Появилась необходимость превратить ссылку в кнопку. Добавил дополнительный параметр.

Для Bootstrap 3 вызываю теперь так:
pay_url t('app.order.pay'), @order.payment.id, @order.payment.amount, {}, {class: 'btn btn-primary btn-bg'}
