### PR TITLE
Fix access for parameters

### DIFF
--- a/lib/rubykassa/notification.rb
+++ b/lib/rubykassa/notification.rb
@@ -8,7 +8,7 @@ module Rubykassa
     attr_accessor :params
 
     def initialize params
-      @params = params
+      @params = HashWithIndifferentAccess.new params
       @invoice_id = params["InvId"]
       @total = params["OutSum"]
     end


### PR DESCRIPTION
For some reason in some cases (When test controller in specs, and if use POST request) I got error `undefined method`downcase' for nil:NilClass`on line`lib/rubykassa/notification.rb:11`. After some debugging I found that in failed cases params hash have symbols in keys. And in success  cases params hash is instance of`HashWithIndifferentAccess`. So I suggest to make force converting to`HashWithIndifferentAccess`.
