### PR TITLE
Make pay_url accept a block like link_to

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 # -*- encoding : utf-8 -*-
 Rails.application.routes.draw do
   if Rubykassa::Client.configuration
-    scope '/robokassa' do
-      %w(paid success fail).map do |route|
-        method(Rubykassa.http_method).call "/#{route}" => "robokassa##{route}", as: "robokassa_#{route}" 
-      end
-    end
+    # scope '/robokassa' do
+    #   %w(paid success fail).map do |route|
+    #     method(Rubykassa.http_method).call "/#{route}" => "robokassa##{route}", as: "robokassa_#{route}" 
+    #   end
+    # end
   end
 end

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -2,6 +2,7 @@
 module Rubykassa
   module ActionViewExtension
     def pay_url(phrase = nil, invoice_id = nil, total = nil, options = {}, &block)
+      invoice_id, total = phrase, invoice_id if block_given?
       total, invoice_id  = total.to_s, invoice_id.to_s
 
       extra_params  = options.except([:custom, :html])

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -9,12 +9,13 @@ module Rubykassa
       custom_params = options[:custom] ||= {}
       html_params = options[:html] ||= {}
 
-      if block_given? 
-        args = [Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params, block]
-      else
-        args = [phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params]
-      end
+      args = [phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params]
 
+      if block_given?
+        args.shift
+        args << block
+      end
+      
       link_to(*args)
     end
   end

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -1,12 +1,12 @@
 # -*- encoding : utf-8 -*-
 module Rubykassa
   module ActionViewExtension
-    def pay_url phrase, invoice_id, total, options = {}
+    def pay_url phrase = nil, invoice_id, total, options = {}, &block
       total, invoice_id  = total.to_s, invoice_id.to_s
       extra_params  = options.except([:custom, :html])
       custom_params = options[:custom] ||= {}
       html_params = options[:html] ||= {}
-      link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params
+      link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params, &block
     end
   end
 end

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -1,11 +1,13 @@
 # -*- encoding : utf-8 -*-
 module Rubykassa
   module ActionViewExtension
-    def pay_url phrase = nil, invoice_id, total, options = {}, &block
+    def pay_url(phrase = nil, invoice_id = nil, total = nil, options = {}, &block)
       total, invoice_id  = total.to_s, invoice_id.to_s
+
       extra_params  = options.except([:custom, :html])
       custom_params = options[:custom] ||= {}
       html_params = options[:html] ||= {}
+
       link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params, &block
     end
   end

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -2,7 +2,7 @@
 module Rubykassa
   module ActionViewExtension
     def pay_url(phrase = nil, invoice_id = nil, total = nil, options = {}, &block)
-      invoice_id, total = phrase, invoice_id if block_given?
+      invoice_id, options, total = phrase, total, invoice_id if block_given?
       total, invoice_id  = total.to_s, invoice_id.to_s
 
       extra_params  = options.except([:custom, :html])
@@ -14,7 +14,7 @@ module Rubykassa
       else
         link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params
       end
-      
+
     end
   end
 end

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -9,14 +9,12 @@ module Rubykassa
       custom_params = options[:custom] ||= {}
       html_params = options[:html] ||= {}
 
-      args = [phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params]
-
       if block_given?
-        args.shift
-        args << block
+        link_to Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params, &block
+      else
+        link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params
       end
       
-      link_to(*args)
     end
   end
 end

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -9,7 +9,13 @@ module Rubykassa
       custom_params = options[:custom] ||= {}
       html_params = options[:html] ||= {}
 
-      link_to phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params, &block
+      if block_given? 
+        args = [Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params, block]
+      else
+        args = [phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params]
+      end
+
+      link_to args
     end
   end
 end

--- a/lib/rubykassa/action_view_extension.rb
+++ b/lib/rubykassa/action_view_extension.rb
@@ -15,7 +15,7 @@ module Rubykassa
         args = [phrase, Rubykassa.pay_url(invoice_id, total, custom_params, extra_params), html_params]
       end
 
-      link_to args
+      link_to(*args)
     end
   end
 end


### PR DESCRIPTION
Привет! I suggest to make pay_url accept block, just like link_to, to be able to construct link content in a more convenient way (template using haml):
```ruby
= pay_url @car_wash.payments.first.id, @car_wash.payments.first.amount do
  .pay-btn
    %div Оплатить с помощью
    %div= image_tag 'robokassa.jpg', size: '150x25'
```
