### PR TITLE
To make this more bullet-proof

### DIFF
--- a/lib/rubykassa/notification.rb
+++ b/lib/rubykassa/notification.rb
@@ -15,7 +15,7 @@ module Rubykassa
 
     %w(result success).map do |kind|
       define_method "valid_#{kind}_signature?" do
-        @params["SignatureValue"].downcase == generate_signature_for(kind.to_sym)
+        @params["SignatureValue"].to_s.downcase == generate_signature_for(kind.to_sym)
       end
     end
 


### PR DESCRIPTION
I updated to Ruby 2.2 and RoR 4.2 and I have started to appear error when processing "... / robokassa / paid":
NoMethodError in RobokassaController # paid
undefined method `downcase 'for nil: NilClass

In this case, something like @params["SignatureValue"] is not defined.
This converts everything to string to start with. nil.to_s is an empty string by default, so it's safe.