### PR TITLE
Change XmlInterface's API to support dynamic attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run `rails g rubykassa:install`, get an initializer with the following code:
       config.xml_http_method = :get # or :post
     end
 
-and configure it with your credentials.    
+and configure it with your credentials.
 
 Also, you need to specify Result URL, Success URL and Fail URL at the "Technical Settings" (Технические настройки) in your Robokassa dashboard:
 
@@ -74,7 +74,7 @@ Additionally you may want to pass extra options. There is no problem:
 
 Or if you would like to pass some custom params use `custom` key in options hash:
 
-    <%= pay_url "Pay with Robokassa", ivoice_id, total_sum, { description: "Invoice description", email: "foo@bar.com", currency: "WMZM", culture: :ru, custom: { param1: "value1", param2: "value2" }} %>      
+    <%= pay_url "Pay with Robokassa", ivoice_id, total_sum, { description: "Invoice description", email: "foo@bar.com", currency: "WMZM", culture: :ru, custom: { param1: "value1", param2: "value2" }} %>
 
 You can also pass some HTML options with `html` key in options hash (Bootstrap 3 example):
 
@@ -82,10 +82,10 @@ You can also pass some HTML options with `html` key in options hash (Bootstrap 3
 
 If you need to implement Robokassa's XML interface functionality you have to the following:
 
-    xml_interface = Rubykassa::XmlInterface.new do
-      self.invoice_id = your_invioce_id
-      self.total = your_total_sum
-      self.language = :ru # can be :en, :ru is default
+    xml_interface = Rubykassa::XmlInterface.new do |interface|
+      interface.invoice_id = your_invioce_id
+      interface.total = your_total_sum
+      interface.language = :ru # can be :en, :ru is default
     end
 
 then call whatever you need
@@ -97,7 +97,7 @@ then call whatever you need
 
 ## Supported Rubies and Rails versions
 
-Rubies: 
+Rubies:
 * 1.9.3
 * 2.0.0
 * 2.1.0

--- a/lib/rubykassa/xml_interface.rb
+++ b/lib/rubykassa/xml_interface.rb
@@ -10,7 +10,7 @@ module Rubykassa
     attr_accessor :invoice_id, :total, :language
 
     def initialize &block
-      instance_eval &block if block_given?
+      yield self if block_given?
     end
 
     def get_currencies
@@ -41,7 +41,7 @@ module Rubykassa
 
     def transform_method_name meth
       meth.to_s.split('_').map(&:capitalize).join(' ').gsub(/\s/, "")
-    end  
+    end
 
     def request url, params
       if Rubykassa.xml_http_method == :get

--- a/spec/rubykassa/xml_interface_spec.rb
+++ b/spec/rubykassa/xml_interface_spec.rb
@@ -2,26 +2,33 @@
 require 'spec_helper'
 
 describe Rubykassa::XmlInterface do
-  before(:each) do
-    @xml_interface = Rubykassa::XmlInterface.new do
-      self.invoice_id = 12
-      self.total = 1200
-      self.language =:ru
-    end
-
-    Rubykassa.configure do |config|
+  subject do
+    described_class.new do |interface|
+      interface.invoice_id = invoice_id
+      interface.total = total
+      interface.language = language
     end
   end
 
-  it "should return correct base_url" do
-    @xml_interface.base_url.should == "https://merchant.roboxchange.com/WebService/Service.asmx/"
+  let(:invoice_id) { 12 }
+  let(:total) { 12_000 }
+  let(:language) { :ru }
+
+  it "sets all passed attributes into initializer block" do
+    expect(subject.invoice_id).to eq(invoice_id)
+    expect(subject.total).to eq(total)
+    expect(subject.language).to eq(language)
   end
 
-  it "should generate correct signature" do
-    @xml_interface.send(:generate_signature).should == "dafff2859f7fd4d110badc476c90fb39"
+  it "returns correct base_url" do
+    expect(subject.base_url).to eq("https://merchant.roboxchange.com/WebService/Service.asmx/")
   end
 
-  it "should correctly transform method name" do
-    @xml_interface.send(:transform_method_name, "some_method_name").should == "SomeMethodName"
+  it "generates correct signature" do
+    expect(subject.send(:generate_signature)).to eq("dafff2859f7fd4d110badc476c90fb39")
+  end
+
+  it "correctly transforms method name" do
+    expect(subject.send(:transform_method_name, "some_method_name")).to eq("SomeMethodName")
   end
 end


### PR DESCRIPTION
Hello,

currently it is a shortcoming that `XmlInterface` is using `instance_eval` for block in initializer, because you can't set a dynamic attribute this way (invoice id in runtime is dynamic), and do some `instance_exec` on the object for the same reason initializer I believe was written for. 

So I suggest to change the implementation for a simple yield to get quite a standard behaviour with passing self object into a block.