### PR TITLE
Add posibility to use XmlInterface in test mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Edge (not released)
 
+* Change `XmlInterface` to support dynamic attributes in initialzer, add posibility to use it in test mode by @vidmantas [#23][], [#24][]
+
+[#23]:https://github.com/ZeroOneStudio/rubykassa/pull/23
+[#24]:https://github.com/ZeroOneStudio/rubykassa/pull/24
+
 ## 0.4.2
 
 * force converting notification params to `HashWithIndifferentAccess` by @shir [#17][], [#18][]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ then call whatever you need
     xml_interface.get_rates
     xml_interface.op_state
 
+In test mode, `op_state` accepts hash with additional attributes you would like to get back with response, for example `{ 'StateCode' => 5 }` (more about [StateCode](http://robokassa.ru/en/Doc/En/Interface.aspx#interfeys)). Please note, that any additional parameters to `op_state` are discarded in production mode.
+
 ## Supported Rubies and Rails versions
 
 Rubies:

--- a/lib/rubykassa/xml_interface.rb
+++ b/lib/rubykassa/xml_interface.rb
@@ -25,15 +25,26 @@ module Rubykassa
       request(base_url + transform_method_name(__method__), Hash["MerchantLogin", Rubykassa.login, "IncCurrLabel", "", "OutSum", @total.to_s, "Language", @language])
     end
 
-    def op_state
-      request(base_url + transform_method_name(__method__), Hash["MerchantLogin", Rubykassa.login, "InvoiceID", @invoice_id.to_s, "Signature", generate_signature])
+    def op_state(additional_params = {})
+      params = Hash["MerchantLogin", Rubykassa.login, "InvoiceID", @invoice_id.to_s, "Signature", generate_signature]
+      params.merge!(additional_params) if test_mode?
+
+      request(base_url + transform_method_name(__method__), params)
     end
 
     def base_url
-      "https://merchant.roboxchange.com/WebService/Service.asmx/"
+      if test_mode?
+        "http://test.robokassa.ru/Webservice/Service.asmx/"
+      else
+        "https://merchant.roboxchange.com/WebService/Service.asmx/"
+      end
     end
 
     private
+
+    def test_mode?
+      Rubykassa.mode == :test
+    end
 
     def generate_signature
       Digest::MD5.hexdigest("#{Rubykassa.login}:#{@invoice_id}:#{Rubykassa.second_password}")

--- a/spec/rubykassa/xml_interface_spec.rb
+++ b/spec/rubykassa/xml_interface_spec.rb
@@ -10,18 +10,18 @@ describe Rubykassa::XmlInterface do
     end
   end
 
+  before(:all) { Rubykassa.configure {} }
+
   let(:invoice_id) { 12 }
   let(:total) { 12_000 }
   let(:language) { :ru }
 
   it "sets all passed attributes into initializer block" do
-    expect(subject.invoice_id).to eq(invoice_id)
-    expect(subject.total).to eq(total)
-    expect(subject.language).to eq(language)
-  end
-
-  it "returns correct base_url" do
-    expect(subject.base_url).to eq("https://merchant.roboxchange.com/WebService/Service.asmx/")
+    aggregate_failures do
+      expect(subject.invoice_id).to eq(invoice_id)
+      expect(subject.total).to eq(total)
+      expect(subject.language).to eq(language)
+    end
   end
 
   it "generates correct signature" do
@@ -30,5 +30,43 @@ describe Rubykassa::XmlInterface do
 
   it "correctly transforms method name" do
     expect(subject.send(:transform_method_name, "some_method_name")).to eq("SomeMethodName")
+  end
+
+  describe "#base_url" do
+    subject { described_class.new.base_url }
+    context "sets to test URL when in test mode" do
+      before { Rubykassa.configure { |c| c.mode = :test } }
+      it { is_expected.to eq("http://test.robokassa.ru/Webservice/Service.asmx/") }
+    end
+
+    context "uses production URL on production" do
+      before { Rubykassa.configure { |c| c.mode = :production } }
+      it { is_expected.to eq("https://merchant.roboxchange.com/WebService/Service.asmx/") }
+    end
+  end
+
+  describe "#op_state" do
+    subject { described_class.new.op_state(params) }
+
+    context "depends on mode" do
+      let(:params) { { "StateCode" => 5 } }
+
+      before do
+        allow(Net::HTTP).to receive(:get_response) do |params|
+          OpenStruct.new(code: "200", body: params.to_s)
+        end
+        allow(MultiXml).to receive(:parse) { |object| object }
+      end
+
+      context "accepts additional params with test mode" do
+        before { Rubykassa.configure { |c| c.mode = :test } }
+        it { is_expected.to eq("http://test.robokassa.ru/Webservice/Service.asmx/OpState?MerchantLogin=your_login&InvoiceID=&Signature=7b7d63d7d72c05ee8470f467bda8adf1&StateCode=5") }
+      end
+
+      context "ignores additional params with production mode" do
+        before { Rubykassa.configure { |c| c.mode = :production } }
+        it { is_expected.to eq("https://merchant.roboxchange.com/WebService/Service.asmx/OpState?MerchantLogin=your_login&InvoiceID=&Signature=7b7d63d7d72c05ee8470f467bda8adf1") }
+      end
+    end
   end
 end


### PR DESCRIPTION
I've also noticed that while `PaymentInterface` can be used in test mode, `XmlInterface` can't, but Robokassa itself supports it. 

This is my try to add this support as well. Backwards compatible.